### PR TITLE
Fix broken link to spec in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Safe{Core} Protocol
 
-This project is an implementation of [Safe{Core} Protocol specification](https://github.com/safe-global/safe-protocol-specs)
+This project is an implementation of [Safe{Core} Protocol specification](https://github.com/safe-global/safe-core-protocol-specs)
 ## Architecture
 
 Safe{Core} Protocol implementation consists of following main components:


### PR DESCRIPTION
There was a broken link to the protocol specification in the README, fixed it to a working one.