### PR TITLE
Add onlyAccount function modifier to setRegistry(address)

### DIFF
--- a/contracts/base/FunctionHandlerManager.sol
+++ b/contracts/base/FunctionHandlerManager.sol
@@ -11,7 +11,7 @@ import {OnlyAccountCallable} from "./OnlyAccountCallable.sol";
  * @notice This contract manages the function handlers for the Safe Account. The contract stores the
  *        information about Safe account, bytes4 function selector and the function handler contract address.
  */
-abstract contract FunctionHandlerManager is RegistryManager, OnlyAccountCallable {
+abstract contract FunctionHandlerManager is RegistryManager {
     // Storage
     /** @dev Mapping that stores information about Safe account, function selector, and address of the account.
      */

--- a/contracts/base/HooksManager.sol
+++ b/contracts/base/HooksManager.sol
@@ -5,7 +5,7 @@ import {ISafeProtocolHooks} from "../interfaces/Modules.sol";
 import {RegistryManager} from "./RegistryManager.sol";
 import {OnlyAccountCallable} from "./OnlyAccountCallable.sol";
 
-abstract contract HooksManager is RegistryManager, OnlyAccountCallable {
+abstract contract HooksManager is RegistryManager {
     mapping(address => address) public enabledHooks;
 
     struct TempHooksInfo {

--- a/contracts/base/RegistryManager.sol
+++ b/contracts/base/RegistryManager.sol
@@ -3,8 +3,9 @@ pragma solidity ^0.8.18;
 import {Ownable2Step} from "@openzeppelin/contracts/access/Ownable2Step.sol";
 import {ISafeProtocolRegistry} from "../interfaces/Registry.sol";
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {OnlyAccountCallable} from "./OnlyAccountCallable.sol";
 
-contract RegistryManager is Ownable2Step {
+contract RegistryManager is Ownable2Step, OnlyAccountCallable {
     address public registry;
 
     event RegistryChanged(address indexed oldRegistry, address indexed newRegistry);
@@ -19,14 +20,12 @@ contract RegistryManager is Ownable2Step {
 
     /*
      * @notice Constructor that sets registry address and owner address.
-     * @dev Do not set owner as a Safe address with Manager enabled as fallback handler.
-     *      If owner is a Safe with Manager enabled as fallback handler, then a malicious
-     *      address can call Safe with calldata that updates registry which gets forwarded to Manager.
-     * @param intitalOwner Address of the owner for this contract.
+     * @param initialOwner Address of the owner for this contract.
+     *        Owner is expected to be an account that appends 20 bytes of caller (i.e. self) address to the calldata when calling setRegistry(address) function.
      * @param _registry address of the account implementing ISafeProtocolRegistry interface.
      */
-    constructor(address _registry, address intitalOwner) {
-        _transferOwnership(intitalOwner);
+    constructor(address _registry, address initialOwner) {
+        _transferOwnership(initialOwner);
         if (!IERC165(_registry).supportsInterface(type(ISafeProtocolRegistry).interfaceId)) {
             revert ContractDoesNotImplementValidInterfaceId(_registry);
         }
@@ -50,7 +49,7 @@ contract RegistryManager is Ownable2Step {
      * @notice Allows only owner to update the address of a registry. Emits event RegistryChanged(egistry, newRegistry)
      * @param newRegistry Address of new registry
      */
-    function setRegistry(address newRegistry) external onlyOwner {
+    function setRegistry(address newRegistry) external onlyOwner onlyAccount {
         if (!IERC165(newRegistry).supportsInterface(type(ISafeProtocolRegistry).interfaceId)) {
             revert ContractDoesNotImplementValidInterfaceId(newRegistry);
         }

--- a/contracts/test/TestExecutor.sol
+++ b/contracts/test/TestExecutor.sol
@@ -15,6 +15,10 @@ contract TestExecutor is ISafe {
         module = _module;
     }
 
+    function setFallbackHandler(address _fallbackHandler) external {
+        fallbackHandler = _fallbackHandler;
+    }
+
     function exec(address payable to, uint256 value, bytes calldata data) external {
         bool success;
         bytes memory response;

--- a/test/base/RegistryManager.spec.ts
+++ b/test/base/RegistryManager.spec.ts
@@ -1,8 +1,7 @@
-import hre from "hardhat";
-import { loadFixture } from "@nomicfoundation/hardhat-toolbox/network-helpers";
+import hre, { deployments } from "hardhat";
 import { expect } from "chai";
 import { SignerWithAddress } from "@nomicfoundation/hardhat-ethers/signers";
-import { ZeroAddress } from "ethers";
+import { MaxUint256, ZeroAddress } from "ethers";
 import { getMockRegistryWithInvalidInterfaceSupport } from "../utils/mockRegistryBuilder";
 
 describe("RegistryManager", async () => {
@@ -12,25 +11,30 @@ describe("RegistryManager", async () => {
         [deployer, owner, user1] = await hre.ethers.getSigners();
     });
 
-    async function deployContractsFixture() {
+    const setupTests = deployments.createFixture(async ({ deployments }) => {
+        await deployments.fixture();
         [deployer, owner, user1] = await hre.ethers.getSigners();
+        const safe = await hre.ethers.deployContract("TestExecutor", [ZeroAddress], { signer: deployer });
+        const safeProtocolRegistry = await hre.ethers.deployContract("SafeProtocolRegistry", [safe.target], { signer: deployer });
 
-        const safeProtocolRegistry = await hre.ethers.deployContract("SafeProtocolRegistry", [owner.address], { signer: deployer });
-        const registryManager = await hre.ethers.deployContract(
-            "RegistryManager",
-            [await safeProtocolRegistry.getAddress(), owner.address],
-            { signer: deployer },
-        );
-        return { registryManager, safeProtocolRegistry };
-    }
+        const registryManager = await hre.ethers.deployContract("RegistryManager", [await safeProtocolRegistry.getAddress(), safe.target], {
+            signer: deployer,
+        });
+
+        await safe.setFallbackHandler(registryManager.target);
+
+        return { registryManager, safeProtocolRegistry, safe };
+    });
 
     it("Should revert when registry address does not implement valid interfaceId", async () => {
-        const { registryManager } = await loadFixture(deployContractsFixture);
+        const { registryManager, safe } = await setupTests();
 
-        await expect(registryManager.connect(owner).setRegistry(ZeroAddress)).to.be.reverted;
+        const dataSetZeroAddressAsRegistry = registryManager.interface.encodeFunctionData("setRegistry", [ZeroAddress]);
+        expect(safe.executeCallViaMock(safe.target, 0n, dataSetZeroAddressAsRegistry, MaxUint256)).to.be.revertedWithoutReason;
 
         const registry = await getMockRegistryWithInvalidInterfaceSupport();
-        await expect(registryManager.connect(owner).setRegistry(await registry.getAddress())).to.be.revertedWithCustomError(
+        const data = registryManager.interface.encodeFunctionData("setRegistry", [registry.target]);
+        await expect(safe.executeCallViaMock(safe.target, 0n, data, MaxUint256)).to.be.revertedWithCustomError(
             registryManager,
             "ContractDoesNotImplementValidInterfaceId",
         );
@@ -43,22 +47,26 @@ describe("RegistryManager", async () => {
     });
 
     it("Should emit RegistryChanged change event when registry is updated", async () => {
-        const { registryManager } = await loadFixture(deployContractsFixture);
+        const { registryManager, safe } = await setupTests();
+
         const safeProtocolRegistryAddress = await (
             await hre.ethers.deployContract("SafeProtocolRegistry", [owner.address], { signer: deployer })
         ).getAddress();
 
-        expect(await registryManager.connect(owner).setRegistry(safeProtocolRegistryAddress))
-            .to.emit(registryManager, "RegistryChanged")
-            .withArgs(await registryManager.getAddress(), safeProtocolRegistryAddress);
+        const data = registryManager.interface.encodeFunctionData("setRegistry", [safeProtocolRegistryAddress]);
+        const oldRegistryAddress = await registryManager.registry.staticCall();
 
-        expect(await registryManager.registry()).to.be.equal(safeProtocolRegistryAddress);
+        await expect(safe.executeCallViaMock(safe.target, 0n, data, MaxUint256))
+            .to.emit(registryManager, "RegistryChanged")
+            .withArgs(oldRegistryAddress, safeProtocolRegistryAddress);
+
+        expect(await registryManager.registry.staticCall()).to.be.equal(safeProtocolRegistryAddress);
     });
 
     it("Should not allow non-owner to update registry", async () => {
         const safe = await hre.ethers.deployContract("TestExecutor", [ZeroAddress]);
 
-        const { registryManager } = await loadFixture(deployContractsFixture);
+        const { registryManager } = await setupTests();
         await safe.setModule(await registryManager.getAddress());
 
         await expect(registryManager.connect(user1).setRegistry(ZeroAddress)).to.be.revertedWith("Ownable: caller is not the owner");

--- a/test/base/RegistryManager.spec.ts
+++ b/test/base/RegistryManager.spec.ts
@@ -71,4 +71,14 @@ describe("RegistryManager", async () => {
 
         await expect(registryManager.connect(user1).setRegistry(ZeroAddress)).to.be.revertedWith("Ownable: caller is not the owner");
     });
+
+    it("Should block calls to setRegistry(address) when caller address is not appended to calldata", async () => {
+        const { registryManager, safe } = await setupTests();
+        const data = registryManager.interface.encodeFunctionData("setRegistry", [ZeroAddress]);
+
+        await expect(safe.executeCallViaMock(registryManager.target, 0n, data, MaxUint256)).to.be.revertedWithCustomError(
+            registryManager,
+            "InvalidSender",
+        );
+    });
 });


### PR DESCRIPTION
Fixes #75 
Changes in PR:
- Inherit `OnlyAccountCallable` in RegistryManager and update other contracts to avoid linearisation error
- Add `onlyAccount` function modifier to `setRegistry(address)`
- Update natspec docstring
- Update tests