### PR TITLE
Fix: remove ISafe interface in the function handler `handle` function signature

### DIFF
--- a/contracts/base/FunctionHandlerManager.sol
+++ b/contracts/base/FunctionHandlerManager.sol
@@ -78,6 +78,6 @@ abstract contract FunctionHandlerManager is RegistryManager {
         // With safe v1.x, msg.data contains 20 bytes of sender address. Read the sender address by loading last 20 bytes.
         // remove last 20 bytes from calldata and store it in `data`.
         // Keep first 4 bytes (i.e function signature) so that handler contract can infer function identifier.
-        return ISafeProtocolFunctionHandler(functionHandler).handle(ISafe(safe), sender, 0, msg.data[0:(msg.data.length - 20)]);
+        return ISafeProtocolFunctionHandler(functionHandler).handle(safe, sender, 0, msg.data[0:(msg.data.length - 20)]);
     }
 }

--- a/contracts/interfaces/Modules.sol
+++ b/contracts/interfaces/Modules.sol
@@ -20,7 +20,7 @@ interface ISafeProtocolFunctionHandler is IERC165 {
      * @param data Arbitrary length bytes
      * @return result Arbitrary length bytes containing result of the operation
      */
-    function handle(ISafe safe, address sender, uint256 value, bytes calldata data) external returns (bytes memory result);
+    function handle(address safe, address sender, uint256 value, bytes calldata data) external returns (bytes memory result);
 
     /**
      * @notice A function that returns information about the type of metadata provider and its location.


### PR DESCRIPTION
I found a blocker while working on the ERC4337 function handler, I inherited `ISafeProtocolFunctionHandler`, and I couldn't get my contract to compile because the handle function had to accept `ISafe safe` as a first argument, but the interface used in the function wasn't any useful for me as it only defined two module execution functions which are irrelevant outside of the protocol context since they're only used for protocol transactions only. I believe this is not needed for two reasons:
- We should allow developers to use whatever interface they want to use
- As far as I know, the Protocol is intended to be used with any account that implements the specifications (that must be defined later). Thus, every account might implement a different interface.

The specs PR: https://github.com/safe-global/safe-core-protocol-specs/pull/38