### PR TITLE
Feat: remove references to a Safe{Core} Protocol account as Safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,27 +3,29 @@
 # Safe{Core} Protocol
 
 This project is an implementation of [Safe{Core} Protocol specification](https://github.com/safe-global/safe-core-protocol-specs)
+
 ## Architecture
 
 Safe{Core} Protocol implementation consists of following main components:
-- [SafeProtocolManager](./contracts/SafeProtocolManager.sol)
-- [SafeProtocolRegistry](./contracts/SafeProtocolRegistry.sol)
-- [Interfaces for Modules](./contracts/interfaces/Modules.sol)
+
+-   [SafeProtocolManager](./contracts/SafeProtocolManager.sol)
+-   [SafeProtocolRegistry](./contracts/SafeProtocolRegistry.sol)
+-   [Interfaces for Modules](./contracts/interfaces/Modules.sol)
 
 A high level overview of the architecture is as follows:
 
 ```mermaid
 graph TD
-    Safe -->|Execute transaction| Monitor
-    Safe -->|Manage Modules| Store
-    Safe -->|SafeProtocolManager handling fallback functionality| FunctionHandlerSupport
+    Account -->|Execute transaction| Monitor
+    Account -->|Manage Modules| Store
+    Account -->|SafeProtocolManager handling fallback functionality| FunctionHandlerSupport
     PluginInstance(Plugin Instance) -->|Execute transaction from Plugin| Monitor
     RegistryOwner("Registry Owner") --> Maintain
     RegistryOwner("Registry Owner") --> Flag
 
 subgraph SafeProtocolManager
 	Store(Maintain Enabled Modules per Safe)
-    Monitor(Mediate Safe transaction execution)
+    Monitor(Mediate Account transaction execution)
     FunctionHandlerSupport("Provide additional functionality using Function Handler(s)")
     HooksSupport("Hooks for validating transaction execution")
     Monitor -.- HooksSupport
@@ -52,12 +54,13 @@ end
 ```
 
 Currently implemented components of the Safe{Core} Protocol are:
-- **SafeProtocolManager**
-- **SafeProtocolRegistry**
-- **Plugins**
-- **Hooks**
-- **Function Handler**
-- Additionally a test version of registry **TestSafeProtocolRegistryUnrestricted** is also available.
+
+-   **SafeProtocolManager**
+-   **SafeProtocolRegistry**
+-   **Plugins**
+-   **Hooks**
+-   **Function Handler**
+-   Additionally a test version of registry **TestSafeProtocolRegistryUnrestricted** is also available.
 
 [Execution flows](./docs/execution_flows.md) give a high-level overview of the different flows for the Safe{Core} Protocol.
 
@@ -89,7 +92,7 @@ contract SamplePlugin is ISafeProtocolPlugin {
     function version() external view returns (string memory version){
         ...
     }
-  
+
     function metadataProvider() external view returns (uint256 providerType, bytes memory location){
         ...
     }
@@ -135,10 +138,11 @@ npx hardhat test
     ```bash
     yarn hardhat deploy --network goerli --tags protocol --export-all deployments.ts
     ```
+
 ### Other commands
 
-| Command                                                                                            | Description                                                                                                                           |
-|----------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------|
-| ``` yarn hardhat generate:deployments ```                                                          | Generate deployments markdown in [./docs/deployments.md](./docs/deployments.md) from [./deployments.ts](./deployments.ts)             |
-| ``` yarn hardhat verify --network goerli <contract_address> <initial_owner> ```                    | Verify Registry contract(s)<br/>  Applicable for<br/> - SafeProtocolRegistry.sol<br/> - TestSafeProtocolRegistryUnrestricted.sol<br/> |
-| ``` yarn hardhat verify --network goerli <contract_address> <initial_owner> <registry_address> ``` | Verify SafeProtocolManager.sol                                                                                                        |
+| Command                                                                                      | Description                                                                                                                          |
+| -------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `yarn hardhat generate:deployments`                                                          | Generate deployments markdown in [./docs/deployments.md](./docs/deployments.md) from [./deployments.ts](./deployments.ts)            |
+| `yarn hardhat verify --network goerli <contract_address> <initial_owner>`                    | Verify Registry contract(s)<br/> Applicable for<br/> - SafeProtocolRegistry.sol<br/> - TestSafeProtocolRegistryUnrestricted.sol<br/> |
+| `yarn hardhat verify --network goerli <contract_address> <initial_owner> <registry_address>` | Verify SafeProtocolManager.sol                                                                                                       |

--- a/contracts/SafeProtocolManager.sol
+++ b/contracts/SafeProtocolManager.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.18;
 import {ISafeProtocolPlugin, ISafeProtocolHooks} from "./interfaces/Modules.sol";
 
-import {ISafe} from "./interfaces/Accounts.sol";
+import {IAccount} from "./interfaces/Accounts.sol";
 import {SafeProtocolAction, SafeTransaction, SafeRootAccess} from "./DataTypes.sol";
 import {ISafeProtocolRegistry} from "./interfaces/Registry.sol";
 import {RegistryManager} from "./base/RegistryManager.sol";
@@ -14,15 +14,16 @@ import {Enum} from "./common/Enum.sol";
 import {PLUGIN_PERMISSION_NONE, PLUGIN_PERMISSION_EXECUTE_CALL, PLUGIN_PERMISSION_CALL_TO_SELF, PLUGIN_PERMISSION_EXECUTE_DELEGATECALL} from "./common/Constants.sol";
 
 /**
- * @title SafeProtocolManager contract allows Safe users to set plugin through a Manager rather than directly enabling a plugin on Safe.
- *        Users have to first enable SafeProtocolManager as a plugin on a Safe and then enable other plugins through the mediator.
+ * @title SafeProtocolManager contract allows users of Accounts compatible with the Safe{Core} Protocol to enable
+ *        plugins through a Manager rather than directly enabling plugins in their Account.
+ *        Users have to first enable SafeProtocolManager as a plugin on their Account and then enable other plugins through the manager.
  */
 contract SafeProtocolManager is ISafeProtocolManager, RegistryManager, HooksManager, FunctionHandlerManager, IERC165 {
     address internal constant SENTINEL_MODULES = address(0x1);
 
     /**
      * @notice Mapping of a mapping what stores information about plugins that are enabled per Safe.
-     *         address (Safe address) => address (module address) => EnabledPluginInfo
+     *         address (Account address) => address (module address) => EnabledPluginInfo
      */
     mapping(address => mapping(address => PluginAccessInfo)) public enabledPlugins;
     struct PluginAccessInfo {
@@ -31,25 +32,25 @@ contract SafeProtocolManager is ISafeProtocolManager, RegistryManager, HooksMana
     }
 
     // Events
-    event ActionsExecuted(address indexed safe, bytes32 metadataHash, uint256 nonce);
-    event RootAccessActionExecuted(address indexed safe, bytes32 metadataHash);
-    event PluginEnabled(address indexed safe, address indexed plugin, uint8 permissions);
-    event PluginDisabled(address indexed safe, address indexed plugin);
+    event ActionsExecuted(address indexed account, bytes32 metadataHash, uint256 nonce);
+    event RootAccessActionExecuted(address indexed account, bytes32 metadataHash);
+    event PluginEnabled(address indexed account, address indexed plugin, uint8 permissions);
+    event PluginDisabled(address indexed account, address indexed plugin);
 
     // Errors
     error PluginNotEnabled(address plugin);
     error MissingPluginPermission(address plugin, uint8 pluginRequires, uint8 requiredPermission, uint8 givenPermission);
     error PluginPermissionsMismatch(address plugin, uint8 requiredPermissions, uint8 givenPermissions);
-    error ActionExecutionFailed(address safe, bytes32 metadataHash, uint256 index);
-    error RootAccessActionExecutionFailed(address safe, bytes32 metadataHash);
-    error PluginAlreadyEnabled(address safe, address plugin);
+    error ActionExecutionFailed(address account, bytes32 metadataHash, uint256 index);
+    error RootAccessActionExecutionFailed(address account, bytes32 metadataHash);
+    error PluginAlreadyEnabled(address account, address plugin);
     error InvalidPluginAddress(address plugin);
     error InvalidPrevPluginAddress(address plugin);
     error ZeroPageSizeNotAllowed();
-    error InvalidToFieldInSafeProtocolAction(address safe, bytes32 metadataHash, uint256 index);
+    error InvalidToFieldInSafeProtocolAction(address account, bytes32 metadataHash, uint256 index);
 
-    modifier onlyEnabledPlugin(address safe) {
-        checkOnlyEnabledPlugin(safe);
+    modifier onlyEnabledPlugin(address account) {
+        checkOnlyEnabledPlugin(account);
         _;
     }
 
@@ -61,30 +62,28 @@ contract SafeProtocolManager is ISafeProtocolManager, RegistryManager, HooksMana
     constructor(address initialOwner, address _registry) RegistryManager(_registry, initialOwner) {}
 
     /**
-     * @notice This function executes non-delegate call(s) on a safe if the plugin is enabled on the Safe.
+     * @notice This function executes non-delegate call(s) on an account if the plugin is enabled for the Account.
      *         If any one of the actions fail, the transaction reverts.
      * @dev Restrict the `to` field in the actions so that a module cannot execute an action that changes the config such as
      *      enabling/disabling other modules or make changes to its own access level for a Safe.
      *      In future, evaluate use of fine granined permissions model executing actions.
      *      For more information, follow the disuccsion here: https://github.com/safe-global/safe-protocol-specs/discussions/7.
-     * @param safe A Safe instance
+     * @param account Target account address
      * @param transaction A struct of type SafeTransaction containing information of about the action(s) to be executed.
      *                    Users can add logic to validate metadataHash through hooks.
      * @return data bytes types containing the result of the executed action.
      */
     function executeTransaction(
-        ISafe safe,
+        address account,
         SafeTransaction calldata transaction
-    ) external override onlyEnabledPlugin(address(safe)) onlyPermittedModule(msg.sender) returns (bytes[] memory data) {
-        address safeAddress = address(safe);
-
-        address hooksAddress = enabledHooks[safeAddress];
+    ) external override onlyEnabledPlugin(account) onlyPermittedModule(msg.sender) returns (bytes[] memory data) {
+        address hooksAddress = enabledHooks[account];
         bool areHooksEnabled = hooksAddress != address(0);
         bytes memory preCheckData;
         if (areHooksEnabled) {
             // execution metadata for transaction execution through plugin is encoded address of the plugin i.e. msg.sender.
             // executionType = 1 for plugin flow
-            preCheckData = ISafeProtocolHooks(hooksAddress).preCheck(safe, transaction, 1, abi.encode(msg.sender));
+            preCheckData = ISafeProtocolHooks(hooksAddress).preCheck(account, transaction, 1, abi.encode(msg.sender));
         }
 
         data = new bytes[](transaction.actions.length);
@@ -93,14 +92,14 @@ contract SafeProtocolManager is ISafeProtocolManager, RegistryManager, HooksMana
             SafeProtocolAction calldata safeProtocolAction = transaction.actions[i];
 
             if (safeProtocolAction.to == address(this)) {
-                revert InvalidToFieldInSafeProtocolAction(safeAddress, transaction.metadataHash, i);
-            } else if (safeProtocolAction.to == safeAddress) {
-                checkPermission(safeAddress, PLUGIN_PERMISSION_CALL_TO_SELF);
+                revert InvalidToFieldInSafeProtocolAction(account, transaction.metadataHash, i);
+            } else if (safeProtocolAction.to == account) {
+                checkPermission(account, PLUGIN_PERMISSION_CALL_TO_SELF);
             } else {
-                checkPermission(safeAddress, PLUGIN_PERMISSION_EXECUTE_CALL);
+                checkPermission(account, PLUGIN_PERMISSION_EXECUTE_CALL);
             }
 
-            (bool isActionSuccessful, bytes memory resultData) = safe.execTransactionFromModuleReturnData(
+            (bool isActionSuccessful, bytes memory resultData) = IAccount(account).execTransactionFromModuleReturnData(
                 safeProtocolAction.to,
                 safeProtocolAction.value,
                 safeProtocolAction.data,
@@ -109,46 +108,45 @@ contract SafeProtocolManager is ISafeProtocolManager, RegistryManager, HooksMana
 
             // Even if one action fails, revert the transaction.
             if (!isActionSuccessful) {
-                revert ActionExecutionFailed(safeAddress, transaction.metadataHash, i);
+                revert ActionExecutionFailed(account, transaction.metadataHash, i);
             } else {
                 data[i] = resultData;
             }
         }
         if (areHooksEnabled) {
             // success = true because if transaction is not revereted till here, all actions executed successfully.
-            ISafeProtocolHooks(hooksAddress).postCheck(ISafe(safe), true, preCheckData);
+            ISafeProtocolHooks(hooksAddress).postCheck(account, true, preCheckData);
         }
-        emit ActionsExecuted(safeAddress, transaction.metadataHash, transaction.nonce);
+        emit ActionsExecuted(account, transaction.metadataHash, transaction.nonce);
     }
 
     /**
-     * @notice This function executes a delegate call on a safe if the plugin is enabled and
-     *         root access it granted.
-     * @param safe A Safe instance
+     * @notice This function executes a delegate call on an account if the plugin is enabled and
+     *         the root access is granted.
+     * @param account Target account address
      * @param rootAccess A struct of type SafeRootAccess containing information of about the action to be executed.
      *                   Users can add logic to validate metadataHash through hooks.
      * @return data bytes types containing the result of the executed action.
      */
     function executeRootAccess(
-        ISafe safe,
+        address account,
         SafeRootAccess calldata rootAccess
-    ) external override onlyEnabledPlugin(address(safe)) onlyPermittedModule(msg.sender) returns (bytes memory data) {
+    ) external override onlyEnabledPlugin(account) onlyPermittedModule(msg.sender) returns (bytes memory data) {
         SafeProtocolAction calldata safeProtocolAction = rootAccess.action;
-        address safeAddress = address(safe);
 
-        address hooksAddress = enabledHooks[safeAddress];
+        address hooksAddress = enabledHooks[account];
         bool areHooksEnabled = hooksAddress != address(0);
         bytes memory preCheckData;
         if (areHooksEnabled) {
             // execution metadata for transaction execution through plugin is encoded address of the plugin i.e. msg.sender.
             // executionType = 1 for plugin flow
-            preCheckData = ISafeProtocolHooks(hooksAddress).preCheckRootAccess(safe, rootAccess, 1, abi.encode(msg.sender));
+            preCheckData = ISafeProtocolHooks(hooksAddress).preCheckRootAccess(account, rootAccess, 1, abi.encode(msg.sender));
         }
 
-        checkPermission(safeAddress, PLUGIN_PERMISSION_EXECUTE_DELEGATECALL);
+        checkPermission(account, PLUGIN_PERMISSION_EXECUTE_DELEGATECALL);
 
         bool success;
-        (success, data) = safe.execTransactionFromModuleReturnData(
+        (success, data) = IAccount(account).execTransactionFromModuleReturnData(
             safeProtocolAction.to,
             safeProtocolAction.value,
             safeProtocolAction.data,
@@ -157,18 +155,18 @@ contract SafeProtocolManager is ISafeProtocolManager, RegistryManager, HooksMana
 
         if (areHooksEnabled) {
             // success = true because if transaction is not revereted till here, all actions executed successfully.
-            ISafeProtocolHooks(hooksAddress).postCheck(ISafe(safe), success, preCheckData);
+            ISafeProtocolHooks(hooksAddress).postCheck(account, success, preCheckData);
         }
 
         if (success) {
-            emit RootAccessActionExecuted(safeAddress, rootAccess.metadataHash);
+            emit RootAccessActionExecuted(account, rootAccess.metadataHash);
         } else {
-            revert RootAccessActionExecutionFailed(safeAddress, rootAccess.metadataHash);
+            revert RootAccessActionExecutionFailed(account, rootAccess.metadataHash);
         }
     }
 
     /**
-     * @notice Called by a Safe to enable a plugin on a Safe. To be called by a safe.
+     * @notice Enables a plugin for an account. Must be called by the account.
      * @param plugin ISafeProtocolPlugin A plugin that has to be enabled
      * @param permissions uint8 indicating permissions granted to the plugin.
      */
@@ -225,24 +223,26 @@ contract SafeProtocolManager is ISafeProtocolManager, RegistryManager, HooksMana
     }
 
     /**
-     * @notice A view only function to get information about safe and a plugin
-     * @param safe Address of a safe
+     * @notice A view only function to get information about an account and a plugin
+     * @param account Address of an account
      * @param plugin Address of a plugin
      */
-    function getPluginInfo(address safe, address plugin) external view returns (PluginAccessInfo memory enabled) {
-        return enabledPlugins[safe][plugin];
+    function getPluginInfo(address account, address plugin) external view returns (PluginAccessInfo memory enabled) {
+        return enabledPlugins[account][plugin];
     }
 
     /**
      * @notice Returns if an plugin is enabled
+     * @param account Address of an account
+     * @param plugin Address of a plugin
      * @return True if the plugin is enabled
      */
-    function isPluginEnabled(address safe, address plugin) public view returns (bool) {
-        return SENTINEL_MODULES != plugin && enabledPlugins[safe][plugin].nextPluginPointer != address(0);
+    function isPluginEnabled(address account, address plugin) public view returns (bool) {
+        return SENTINEL_MODULES != plugin && enabledPlugins[account][plugin].nextPluginPointer != address(0);
     }
 
     /**
-     * @notice Returns an array of plugins enabled for a Safe address.
+     * @notice Returns an array of plugins enabled for an account address.
      *         If all entries fit into a single page, the next pointer will be 0x1.
      *         If another page is present, next will be the last element of the returned array.
      * @param start Start of the page. Has to be a plugin or start pointer (0x1 address)
@@ -253,13 +253,13 @@ contract SafeProtocolManager is ISafeProtocolManager, RegistryManager, HooksMana
     function getPluginsPaginated(
         address start,
         uint256 pageSize,
-        address safe
+        address account
     ) external view returns (address[] memory array, address next) {
         if (pageSize == 0) {
             revert ZeroPageSizeNotAllowed();
         }
 
-        if (!(start == SENTINEL_MODULES || isPluginEnabled(safe, start))) {
+        if (!(start == SENTINEL_MODULES || isPluginEnabled(account, start))) {
             revert InvalidPluginAddress(start);
         }
         // Init array with max page size
@@ -267,14 +267,14 @@ contract SafeProtocolManager is ISafeProtocolManager, RegistryManager, HooksMana
 
         // Populate return array
         uint256 pluginCount = 0;
-        next = enabledPlugins[safe][start].nextPluginPointer;
+        next = enabledPlugins[account][start].nextPluginPointer;
         while (next != address(0) && next != SENTINEL_MODULES && pluginCount < pageSize) {
             array[pluginCount] = next;
-            next = enabledPlugins[safe][next].nextPluginPointer;
+            next = enabledPlugins[account][next].nextPluginPointer;
             pluginCount++;
         }
 
-        // This check is required because the enabled plugin list might not be initialised yet. e.g. no enabled plugins for a safe ever before
+        // This check is required because the enabled plugin list might not be initialised yet. e.g. no enabled plugins for an account ever before
         if (pluginCount == 0) {
             next = SENTINEL_MODULES;
         }
@@ -298,8 +298,8 @@ contract SafeProtocolManager is ISafeProtocolManager, RegistryManager, HooksMana
     }
 
     /**
-     * @notice Implement BaseGuard interface to allow Safe to add Manager as a guard for existing Safe accounts (upto version 1.5.x).
-     * @dev A Safe must enable SafeProtocolManager as a Guard (for Safe v1.x) and enable a contract address as Hooks.
+     * @notice Implement BaseGuard interface to allow an account to add Manager as a guard for existing Safe accounts (upto version 1.5.x).
+     * @dev An account must enable SafeProtocolManager as a Guard (for Safe v1.x) and enable a contract address as Hooks.
      *      If there is no hooks enabled for the Safe, transaction will pass through without any checks.
      * @param to address of the account
      * @param value Amount of ETH to be sent
@@ -329,9 +329,9 @@ contract SafeProtocolManager is ISafeProtocolManager, RegistryManager, HooksMana
         // Store hooks address in tempHooksAddress so that checkAfterExecution(...) can access it.
         // A temprary storage is required to use old hooks in checkAfterExecution if hooks get updated in between transaction
         tempHooksData[msg.sender].hooksAddress = enabledHooks[msg.sender];
-        address tempHooksAddressForSafe = enabledHooks[msg.sender];
+        address tempHooksAddressForAccount = enabledHooks[msg.sender];
 
-        if (tempHooksAddressForSafe == address(0)) return;
+        if (tempHooksAddressForAccount == address(0)) return;
         bytes memory executionMetadata = abi.encode(
             to,
             value,
@@ -349,19 +349,19 @@ contract SafeProtocolManager is ISafeProtocolManager, RegistryManager, HooksMana
             SafeProtocolAction[] memory actions = new SafeProtocolAction[](1);
             actions[0] = SafeProtocolAction(payable(to), value, data);
             SafeTransaction memory safeTx = SafeTransaction(actions, 0, "");
-            tempHooksData[msg.sender].preCheckData = ISafeProtocolHooks(tempHooksAddressForSafe).preCheck(
-                ISafe(msg.sender),
+            tempHooksData[msg.sender].preCheckData = ISafeProtocolHooks(tempHooksAddressForAccount).preCheck(
+                msg.sender,
                 safeTx,
                 0,
                 executionMetadata
             );
         } else {
             // Using else instead of "else if(operation == Enum.Operation.DelegateCall)" to reduce gas usage
-            // and Safe allows only Call and DelegateCall operations.
+            // because accounts must only allow Call and DelegateCall operations.
             SafeProtocolAction memory action = SafeProtocolAction(payable(to), value, data);
             SafeRootAccess memory safeTx = SafeRootAccess(action, 0, "");
-            tempHooksData[msg.sender].preCheckData = ISafeProtocolHooks(tempHooksAddressForSafe).preCheckRootAccess(
-                ISafe(msg.sender),
+            tempHooksData[msg.sender].preCheckData = ISafeProtocolHooks(tempHooksAddressForAccount).preCheckRootAccess(
+                msg.sender,
                 safeTx,
                 0,
                 executionMetadata
@@ -374,11 +374,11 @@ contract SafeProtocolManager is ISafeProtocolManager, RegistryManager, HooksMana
      * @param success bool
      */
     function checkAfterExecution(bytes32, bool success) external {
-        address tempHooksAddressForSafe = tempHooksData[msg.sender].hooksAddress;
-        if (tempHooksAddressForSafe == address(0)) return;
+        address tempHooksAddressForAccount = tempHooksData[msg.sender].hooksAddress;
+        if (tempHooksAddressForAccount == address(0)) return;
 
         // Use tempHooksAddress to avoid a case where hooks get updated in the middle of a transaction.
-        ISafeProtocolHooks(tempHooksAddressForSafe).postCheck(ISafe(msg.sender), success, tempHooksData[msg.sender].preCheckData);
+        ISafeProtocolHooks(tempHooksAddressForAccount).postCheck(msg.sender, success, tempHooksData[msg.sender].preCheckData);
 
         // Reset to address(0) so that there is no unattended storage
         tempHooksData[msg.sender].hooksAddress = address(0);
@@ -405,22 +405,22 @@ contract SafeProtocolManager is ISafeProtocolManager, RegistryManager, HooksMana
         // Store hooks address in tempHooksAddress so that checkAfterExecution(...) can access it.
         // A temprary storage is required to use old hooks in checkAfterExecution if hooks get updated in between transaction
         tempHooksData[msg.sender].hooksAddress = enabledHooks[msg.sender];
-        address tempHooksAddressForSafe = enabledHooks[msg.sender];
+        address tempHooksAddressForAccount = enabledHooks[msg.sender];
 
         moduleTxHash = keccak256(abi.encode(to, value, data, operation, module));
-        if (tempHooksAddressForSafe == address(0)) return moduleTxHash;
+        if (tempHooksAddressForAccount == address(0)) return moduleTxHash;
 
         if (operation == Enum.Operation.Call) {
             SafeProtocolAction[] memory actions = new SafeProtocolAction[](1);
             actions[0] = SafeProtocolAction(payable(to), value, data);
             SafeTransaction memory safeTx = SafeTransaction(actions, 0, "");
-            ISafeProtocolHooks(tempHooksAddressForSafe).preCheck(ISafe(msg.sender), safeTx, 1, abi.encode(module));
+            ISafeProtocolHooks(tempHooksAddressForAccount).preCheck(msg.sender, safeTx, 1, abi.encode(module));
         } else {
             // Using else instead of "else if(operation == Enum.Operation.DelegateCall)" to reduce gas usage
             // and Safe allows only Call and DelegateCall operations.
             SafeProtocolAction memory action = SafeProtocolAction(payable(to), value, data);
             SafeRootAccess memory safeTx = SafeRootAccess(action, 0, "");
-            ISafeProtocolHooks(tempHooksAddressForSafe).preCheckRootAccess(ISafe(msg.sender), safeTx, 1, abi.encode(module));
+            ISafeProtocolHooks(tempHooksAddressForAccount).preCheckRootAccess(msg.sender, safeTx, 1, abi.encode(module));
         }
 
         return moduleTxHash;
@@ -434,8 +434,8 @@ contract SafeProtocolManager is ISafeProtocolManager, RegistryManager, HooksMana
             interfaceId == type(IERC165).interfaceId; // 0x01ffc9a7
     }
 
-    function checkOnlyEnabledPlugin(address safe) private view {
-        if (enabledPlugins[safe][msg.sender].nextPluginPointer == address(0)) {
+    function checkOnlyEnabledPlugin(address account) private view {
+        if (enabledPlugins[account][msg.sender].nextPluginPointer == address(0)) {
             revert PluginNotEnabled(msg.sender);
         }
     }

--- a/contracts/SafeProtocolManager.sol
+++ b/contracts/SafeProtocolManager.sol
@@ -22,7 +22,7 @@ contract SafeProtocolManager is ISafeProtocolManager, RegistryManager, HooksMana
     address internal constant SENTINEL_MODULES = address(0x1);
 
     /**
-     * @notice Mapping of a mapping what stores information about plugins that are enabled per Safe.
+     * @notice Mapping of a mapping what stores information about plugins that are enabled per account.
      *         address (Account address) => address (module address) => EnabledPluginInfo
      */
     mapping(address => mapping(address => PluginAccessInfo)) public enabledPlugins;
@@ -65,7 +65,7 @@ contract SafeProtocolManager is ISafeProtocolManager, RegistryManager, HooksMana
      * @notice This function executes non-delegate call(s) on an account if the plugin is enabled for the Account.
      *         If any one of the actions fail, the transaction reverts.
      * @dev Restrict the `to` field in the actions so that a module cannot execute an action that changes the config such as
-     *      enabling/disabling other modules or make changes to its own access level for a Safe.
+     *      enabling/disabling other modules or make changes to its own access level for an account.
      *      In future, evaluate use of fine granined permissions model executing actions.
      *      For more information, follow the disuccsion here: https://github.com/safe-global/safe-protocol-specs/discussions/7.
      * @param account Target account address
@@ -203,7 +203,7 @@ contract SafeProtocolManager is ISafeProtocolManager, RegistryManager, HooksMana
     }
 
     /**
-     * @notice Disable a plugin. This function should be called by Safe.
+     * @notice Disable a plugin. This function should be called by account.
      * @param plugin Plugin to be disabled
      */
     function disablePlugin(address prevPlugin, address plugin) external noZeroOrSentinelPlugin(plugin) onlyAccount {

--- a/contracts/base/FunctionHandlerManager.sol
+++ b/contracts/base/FunctionHandlerManager.sol
@@ -2,39 +2,39 @@
 pragma solidity ^0.8.18;
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import {ISafeProtocolFunctionHandler} from "../interfaces/Modules.sol";
-import {ISafe} from "../interfaces/Accounts.sol";
+
 import {RegistryManager} from "./RegistryManager.sol";
 import {OnlyAccountCallable} from "./OnlyAccountCallable.sol";
 
 /**
  * @title FunctionHandlerManager
- * @notice This contract manages the function handlers for the Safe Account. The contract stores the
- *        information about Safe account, bytes4 function selector and the function handler contract address.
+ * @notice This contract manages the function handlers for an Account. The contract stores the
+ *        information about an account, bytes4 function selector and the function handler contract address.
  */
 abstract contract FunctionHandlerManager is RegistryManager {
     // Storage
-    /** @dev Mapping that stores information about Safe account, function selector, and address of the account.
+    /** @dev Mapping that stores information about an account, function selector, and address of the account.
      */
     mapping(address => mapping(bytes4 => address)) public functionHandlers;
 
     // Events
-    event FunctionHandlerChanged(address indexed safe, bytes4 indexed selector, address indexed functionHandler);
+    event FunctionHandlerChanged(address indexed account, bytes4 indexed selector, address indexed functionHandler);
 
     // Errors
-    error FunctionHandlerNotSet(address safe, bytes4 functionSelector);
+    error FunctionHandlerNotSet(address account, bytes4 functionSelector);
 
     /**
-     * @notice Returns the function handler for a Safe account and function selector.
-     * @param safe Address of the Safe account
+     * @notice Returns the function handler for an account and function selector.
+     * @param account Address of an account
      * @param selector bytes4 function selector
      * @return functionHandler Address of the contract to be set as a function handler
      */
-    function getFunctionHandler(address safe, bytes4 selector) external view returns (address functionHandler) {
-        functionHandler = functionHandlers[safe][selector];
+    function getFunctionHandler(address account, bytes4 selector) external view returns (address functionHandler) {
+        functionHandler = functionHandlers[account][selector];
     }
 
     /**
-     * @notice Sets the function handler for a Safe account and function selector. The msg.sender must be the account.
+     * @notice Sets the function handler for an account and function selector. The msg.sender must be the account.
      *         This function checks if the functionHandler address is listed and not flagged in the registry.
      * @param selector bytes4 function selector
      * @param functionHandler Address of the contract to be set as a function handler
@@ -52,21 +52,21 @@ abstract contract FunctionHandlerManager is RegistryManager {
     }
 
     /**
-     * @notice This fallback handler function checks if a safe (msg.sender) has a function handler enabled.
+     * @notice This fallback handler function checks if an account (msg.sender) has a function handler enabled.
      *         If enabled, calls handle function and returns the result back.
      *         Currently, the handle(...) function is non-payable and has same signature for both ISafeProtocolFunctionHandler
      *         and ISafeProtocolStaticFunctionHandler. So, ISafeProtocolFunctionHandler.handle is used even for static calls.
      */
     // solhint-disable-next-line no-complex-fallback, payable-fallback
     fallback(bytes calldata) external returns (bytes memory) {
-        address safe = msg.sender;
+        address account = msg.sender;
         bytes4 functionSelector = bytes4(msg.data);
 
-        address functionHandler = functionHandlers[safe][functionSelector];
+        address functionHandler = functionHandlers[account][functionSelector];
 
         // Revert if functionHandler is not set
         if (functionHandler == address(0)) {
-            revert FunctionHandlerNotSet(safe, functionSelector);
+            revert FunctionHandlerNotSet(account, functionSelector);
         }
 
         address sender;
@@ -75,9 +75,9 @@ abstract contract FunctionHandlerManager is RegistryManager {
             sender := shr(96, calldataload(sub(calldatasize(), 20)))
         }
 
-        // With safe v1.x, msg.data contains 20 bytes of sender address. Read the sender address by loading last 20 bytes.
+        // With a Safe{Core} Account v1.x, msg.data contains 20 bytes of sender address. Read the sender address by loading last 20 bytes.
         // remove last 20 bytes from calldata and store it in `data`.
         // Keep first 4 bytes (i.e function signature) so that handler contract can infer function identifier.
-        return ISafeProtocolFunctionHandler(functionHandler).handle(safe, sender, 0, msg.data[0:(msg.data.length - 20)]);
+        return ISafeProtocolFunctionHandler(functionHandler).handle(account, sender, 0, msg.data[0:(msg.data.length - 20)]);
     }
 }

--- a/contracts/base/HooksManager.sol
+++ b/contracts/base/HooksManager.sol
@@ -18,20 +18,20 @@ abstract contract HooksManager is RegistryManager {
     mapping(address => TempHooksInfo) public tempHooksData;
 
     // Events
-    event HooksChanged(address indexed safe, address indexed hooksAddress);
+    event HooksChanged(address indexed account, address indexed hooksAddress);
 
     /**
-     * @notice Returns the address of hooks for a Safe account provided as a fucntion parameter.
+     * @notice Returns the address of hooks for an account provided as a function parameter.
      *         Returns address(0) is no hooks are enabled.
-     * @param safe Address of a Safe account
-     * @return hooksAddress Address of hooks enabled for on Safe account
+     * @param account Address of an account
+     * @return hooksAddress Address of hooks enabled for the account
      */
-    function getEnabledHooks(address safe) external view returns (address hooksAddress) {
-        hooksAddress = enabledHooks[safe];
+    function getEnabledHooks(address account) external view returns (address hooksAddress) {
+        hooksAddress = enabledHooks[account];
     }
 
     /**
-     * @notice Sets hooks on an account. If Zero address is set, manager will not perform pre and post checks for on Safe transaction.
+     * @notice Sets hooks on an account. If Zero address is set, manager will not perform pre and post checks for account transactions.
      * @param hooks Address of the hooks to be enabled for msg.sender.
      */
     function setHooks(address hooks) external onlyAccount {

--- a/contracts/common/Enum.sol
+++ b/contracts/common/Enum.sol
@@ -9,7 +9,7 @@ abstract contract Enum {
     }
 
     /**
-     * @title Enum - Collection of enums used in Safe contracts.
+     * @title Enum - Collection of enums used in Safe{Core} Account contracts.
      * @dev Source: https://github.com/safe-global/safe-contracts/blob/7d767973bd21e2d621a4895fdaf9524132efc2f9/contracts/common/Enum.sol#L8
      */
     enum Operation {

--- a/contracts/interfaces/Accounts.sol
+++ b/contracts/interfaces/Accounts.sol
@@ -2,9 +2,9 @@
 pragma solidity ^0.8.18;
 
 /**
- * @title ISafe Declares the functions that are called on a Safe by Safe{Core} Protocol.
+ * @title IAccount Declares the functions that are called on an account by Safe{Core} Protocol.
  */
-interface ISafe {
+interface IAccount {
     function execTransactionFromModule(
         address payable to,
         uint256 value,

--- a/contracts/interfaces/Manager.sol
+++ b/contracts/interfaces/Manager.sol
@@ -1,32 +1,32 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.18;
-import {ISafe} from "./Accounts.sol";
+
 import {SafeRootAccess, SafeTransaction} from "../DataTypes.sol";
 
 /**
  * @title ISafeProtocolManager interface a Manager should implement
- * @notice A mediator checks the status of the module through the registry and allows only
- *         listed and non-flagged modules to execute transactions. A Safe account should
- *         add a mediator as a plugin.
+ * @notice A manager checks the status of the module through the registry and allows only
+ *         listed and non-flagged modules to execute transactions. An account should
+ *         add the manager as a plugin.
  */
 interface ISafeProtocolManager {
     /**
      * @notice This function allows enabled plugins to execute non-delegate call transactions thorugh a Safe.
      *         It should validate the status of the plugin through the registry and allows only listed and non-flagged modules to execute transactions.
-     * @param safe Address of a Safe account
+     * @param account Address of an account
      * @param transaction SafeTransaction instance containing payload information about the transaction
      * @return data Array of bytes types returned upon the successful execution of all the actions. The size of the array will be the same as the size of the actions
      *         in case of succcessful execution. Empty if the call failed.
      */
-    function executeTransaction(ISafe safe, SafeTransaction calldata transaction) external returns (bytes[] memory data);
+    function executeTransaction(address account, SafeTransaction calldata transaction) external returns (bytes[] memory data);
 
     /**
      * @notice This function allows enabled plugins to execute delegate call transactions thorugh a Safe.
      *         It should validate the status of the plugin through the registry and allows only listed and non-flagged modules to execute transactions.
-     * @param safe Address of a Safe account
+     * @param account Address of an account
      * @param rootAccess SafeTransaction instance containing payload information about the transaction
      * @return data Arbitrary length bytes data returned upon the successful execution. The size of the array will be the same as the size of the actions
      *         in case of succcessful execution. Empty if the call failed.
      */
-    function executeRootAccess(ISafe safe, SafeRootAccess calldata rootAccess) external returns (bytes memory data);
+    function executeRootAccess(address account, SafeRootAccess calldata rootAccess) external returns (bytes memory data);
 }

--- a/contracts/interfaces/Manager.sol
+++ b/contracts/interfaces/Manager.sol
@@ -11,7 +11,7 @@ import {SafeRootAccess, SafeTransaction} from "../DataTypes.sol";
  */
 interface ISafeProtocolManager {
     /**
-     * @notice This function allows enabled plugins to execute non-delegate call transactions thorugh a Safe.
+     * @notice This function allows enabled plugins to execute non-delegate call transactions through a account.
      *         It should validate the status of the plugin through the registry and allows only listed and non-flagged modules to execute transactions.
      * @param account Address of an account
      * @param transaction SafeTransaction instance containing payload information about the transaction
@@ -21,7 +21,7 @@ interface ISafeProtocolManager {
     function executeTransaction(address account, SafeTransaction calldata transaction) external returns (bytes[] memory data);
 
     /**
-     * @notice This function allows enabled plugins to execute delegate call transactions thorugh a Safe.
+     * @notice This function allows enabled plugins to execute delegate call transactions through a account.
      *         It should validate the status of the plugin through the registry and allows only listed and non-flagged modules to execute transactions.
      * @param account Address of an account
      * @param rootAccess SafeTransaction instance containing payload information about the transaction

--- a/contracts/interfaces/Modules.sol
+++ b/contracts/interfaces/Modules.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.18;
-import {ISafe} from "./Accounts.sol";
+
 import {SafeTransaction, SafeRootAccess} from "../DataTypes.sol";
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 /**
- * @title ISafeProtocolFunctionHandler - An interface that a Safe function handler should implement to handle static calls.
+ * @title ISafeProtocolFunctionHandler - An interface that an Account function handler should implement to handle static calls.
  * @notice In Safe{Core} Protocol, a function handler can be used to add additional functionality to a Safe.
  *         User(s) should add SafeProtocolManager as a function handler (aka fallback handler in Safe v1.x) to the Safe
  *         and enable the contract implementing ISafeProtocolFunctionHandler interface as a function handler in the
@@ -13,14 +13,14 @@ import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
  */
 interface ISafeProtocolFunctionHandler is IERC165 {
     /**
-     * @notice Handles calls to the Safe contract forwarded by the fallback function.
-     * @param safe A Safe instance
+     * @notice Handles calls to the account contract forwarded by the fallback function.
+     * @param account Address of the account
      * @param sender Address of the sender
      * @param value Amount of ETH
      * @param data Arbitrary length bytes
      * @return result Arbitrary length bytes containing result of the operation
      */
-    function handle(address safe, address sender, uint256 value, bytes calldata data) external returns (bytes memory result);
+    function handle(address account, address sender, uint256 value, bytes calldata data) external returns (bytes memory result);
 
     /**
      * @notice A function that returns information about the type of metadata provider and its location.
@@ -32,7 +32,7 @@ interface ISafeProtocolFunctionHandler is IERC165 {
 }
 
 /**
- * @title ISafeProtocolStaticFunctionHandler - An interface that a Safe functionhandler should implement in case when handling static calls
+ * @title ISafeProtocolStaticFunctionHandler - An interface that a Safe{Core} Protocol Function handler should implement in case when handling static calls
  * @notice In Safe{Core} Protocol, a function handler can be used to add additional functionality to a Safe.
  *         User(s) should add SafeProtocolManager as a function handler (aka fallback handler in Safe v1.x) to the Safe
  *         and enable the contract implementing ISafeProtocolStaticFunctionHandler interface as a function handler in the
@@ -40,14 +40,14 @@ interface ISafeProtocolFunctionHandler is IERC165 {
  */
 interface ISafeProtocolStaticFunctionHandler is IERC165 {
     /**
-     * @notice Handles static calls to the Safe contract forwarded by the fallback function.
-     * @param safe A Safe instance
+     * @notice Handles static calls to the account contract forwarded by the fallback function.
+     * @param account Address of the account
      * @param sender Address of the sender
      * @param value Amount of ETH
      * @param data Arbitrary length bytes
      * @return result Arbitrary length bytes containing result of the operation
      */
-    function handle(ISafe safe, address sender, uint256 value, bytes calldata data) external view returns (bytes memory result);
+    function handle(address account, address sender, uint256 value, bytes calldata data) external view returns (bytes memory result);
 
     /**
      * @notice A function that returns information about the type of metadata provider and its location.
@@ -64,50 +64,50 @@ interface ISafeProtocolStaticFunctionHandler is IERC165 {
  */
 interface ISafeProtocolHooks is IERC165 {
     /**
-     * @notice A function that will be called by a Safe before the execution of a transaction if the hooks are enabled
+     * @notice A function that will be called before the execution of a transaction if the hooks are enabled
      * @dev Add custom logic in this function to validate the pre-state and contents of transaction for non-root access.
-     * @param safe A Safe instance
+     * @param account Address of the account
      * @param tx A struct of type SafeTransaction that contains the details of the transaction.
      * @param executionType uint256
      * @param executionMeta Arbitrary length of bytes
      * @return preCheckData bytes
      */
     function preCheck(
-        ISafe safe,
+        address account,
         SafeTransaction calldata tx,
         uint256 executionType,
         bytes calldata executionMeta
     ) external returns (bytes memory preCheckData);
 
     /**
-     * @notice A function that will be called by a safe before the execution of a transaction if the hooks are enabled and
-     *         transaction requies tool access.
+     * @notice A function that will be called before the execution of a transaction if the hooks are enabled and
+     *         transaction requies root access.
      * @dev Add custom logic in this function to validate the pre-state and contents of transaction for root access.
-     * @param safe A Safe instance
+     * @param account Address of the account
      * @param rootAccess DataTypes.SafeRootAccess
      * @param executionType uint256
      * @param executionMeta bytes
      * @return preCheckData bytes
      */
     function preCheckRootAccess(
-        ISafe safe,
+        address account,
         SafeRootAccess calldata rootAccess,
         uint256 executionType,
         bytes calldata executionMeta
     ) external returns (bytes memory preCheckData);
 
     /**
-     * @notice A function that will be called by a safe after the execution of a transaction if the hooks are enabled. Hooks should revert if the post state of after the transaction is not as expected.
+     * @notice A function that will be called after the execution of a transaction if the hooks are enabled. Hooks should revert if the post state of after the transaction is not as expected.
      * @dev Add custom logic in this function to validate the post-state after the transaction is executed.
-     * @param safe ISafe
+     * @param account Address of the account
      * @param success bool
      * @param preCheckData Arbitrary length bytes that was returned by during pre-check of the transaction.
      */
-    function postCheck(ISafe safe, bool success, bytes calldata preCheckData) external;
+    function postCheck(address account, bool success, bytes calldata preCheckData) external;
 }
 
 /**
- * @title ISafeProtocolPlugin - An interface that a Safe plugin should implement
+ * @title ISafeProtocolPlugin - An interface that a Safe{Core} Protocol Plugin should implement
  */
 interface ISafeProtocolPlugin is IERC165 {
     /**

--- a/contracts/interfaces/Modules.sol
+++ b/contracts/interfaces/Modules.sol
@@ -6,8 +6,8 @@ import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 /**
  * @title ISafeProtocolFunctionHandler - An interface that an Account function handler should implement to handle static calls.
- * @notice In Safe{Core} Protocol, a function handler can be used to add additional functionality to a Safe.
- *         User(s) should add SafeProtocolManager as a function handler (aka fallback handler in Safe v1.x) to the Safe
+ * @notice In Safe{Core} Protocol, a function handler can be used to add additional functionality to an account.
+ *         User(s) should add SafeProtocolManager as a function handler (aka fallback handler in Safe v1.x) to the account
  *         and enable the contract implementing ISafeProtocolFunctionHandler interface as a function handler in the
  *         SafeProtocolManager for the specific function identifier.
  */
@@ -33,8 +33,8 @@ interface ISafeProtocolFunctionHandler is IERC165 {
 
 /**
  * @title ISafeProtocolStaticFunctionHandler - An interface that a Safe{Core} Protocol Function handler should implement in case when handling static calls
- * @notice In Safe{Core} Protocol, a function handler can be used to add additional functionality to a Safe.
- *         User(s) should add SafeProtocolManager as a function handler (aka fallback handler in Safe v1.x) to the Safe
+ * @notice In Safe{Core} Protocol, a function handler can be used to add additional functionality to an account.
+ *         User(s) should add SafeProtocolManager as a function handler (aka fallback handler in Safe v1.x) to the account
  *         and enable the contract implementing ISafeProtocolStaticFunctionHandler interface as a function handler in the
  *         SafeProtocolManager for the specific function identifier.
  */

--- a/contracts/test/TestExecutor.sol
+++ b/contracts/test/TestExecutor.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.18;
-import {ISafe} from "../interfaces/Accounts.sol";
+import {IAccount} from "../interfaces/Accounts.sol";
 
-contract TestExecutor is ISafe {
+contract TestExecutor is IAccount {
     address public module;
     address[] public owners;
     address public fallbackHandler;

--- a/contracts/test/TestPlugin.sol
+++ b/contracts/test/TestPlugin.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.18;
 
-import {ISafe} from "../interfaces/Accounts.sol";
+import {IAccount} from "../interfaces/Accounts.sol";
 import {ISafeProtocolPlugin} from "../interfaces/Modules.sol";
 import {ISafeProtocolManager} from "../interfaces/Manager.sol";
 import {SafeTransaction, SafeRootAccess} from "../DataTypes.sol";
@@ -34,10 +34,10 @@ contract TestPlugin is BaseTestPlugin {
 
     function executeFromPlugin(
         ISafeProtocolManager manager,
-        ISafe safe,
+        address account,
         SafeTransaction calldata safetx
     ) external returns (bytes[] memory data) {
-        (data) = manager.executeTransaction(safe, safetx);
+        (data) = manager.executeTransaction(account, safetx);
     }
 }
 
@@ -48,9 +48,9 @@ contract TestPluginWithRootAccess is TestPlugin {
 
     function executeRootAccessTxFromPlugin(
         ISafeProtocolManager manager,
-        ISafe safe,
+        address account,
         SafeRootAccess calldata safeRootAccesstx
     ) external returns (bytes memory data) {
-        (data) = manager.executeRootAccess(safe, safeRootAccesstx);
+        (data) = manager.executeRootAccess(account, safeRootAccesstx);
     }
 }

--- a/docs/execution_flows.md
+++ b/docs/execution_flows.md
@@ -36,7 +36,7 @@ title: Safe{Core} Protocol High-level Plugin execution flow
 flowchart TD;
    TxExecuteFromPlugin(Call to Plugin to execute tx ) --> ExamplePlugin1
    Account --> Execute_Transaction_From_Plugin(Execute transaction)
-   Validate_ExecuteFromPluginFlow -- Yes --> Account(Safe{Core} Protocol Account)
+   Validate_ExecuteFromPluginFlow -- Yes --> Account("Safe{Core} Protocol Account")
 subgraph Plugins
    ExamplePlugin1(Sample Plugin)
 end

--- a/docs/execution_flows.md
+++ b/docs/execution_flows.md
@@ -6,19 +6,19 @@ The below sections provide a high-level overview of the execution different flow
 
 ```mermaid
 ---
-title: Safe{Core} Protocol High-level execution flow for enabling Module
+title: Safe{Core} Protocol High-level execution flow for enabling a Module
 ---
 flowchart TD;
 subgraph Users
    User(User)
 end
 
-subgraph SafeAccounts
-   User(User) -->|Call manager to enable Sample Plugin| SafeAccount
+subgraph Accounts
+   User(User) -->|Call manager to enable Sample Plugin| Account
 end
 
 subgraph SafeProtocolManager
-    SafeAccount -->|Enable Sample Plugin Tx| Enable_Module(Enable Module on a Safe)
+    Account -->|Enable Sample Plugin Tx| Enable_Module(Enable Module on a Safe)
     Enable_Plugin --> Validator{Is Sample Module trusted?<br>Call SafeProtocolRegistry}
     Validator -- Yes --> C(Sample Module enabled on Safe)
     Validator -- No ----> E(Revert transaction)
@@ -35,19 +35,19 @@ title: Safe{Core} Protocol High-level Plugin execution flow
 ---
 flowchart TD;
    TxExecuteFromPlugin(Call to Plugin to execute tx ) --> ExamplePlugin1
-   Safe --> Execute_Transaction_From_Plugin(Execute transaction)
-   Validate_ExecuteFromPluginFlow -- Yes --> Safe(Safe Account)
+   Account --> Execute_Transaction_From_Plugin(Execute transaction)
+   Validate_ExecuteFromPluginFlow -- Yes --> Account(Safe{Core} Protocol Account)
 subgraph Plugins
    ExamplePlugin1(Sample Plugin)
 end
 
 subgraph SafeProtocolManager
-    ExamplePlugin1 -->|Execute tx for a Safe through Plugin| Execute_Transaction(Execute transaction from a Plugin) --> Validate_ExecuteFromPluginFlow{Is Plugin Enabled?<br>Call SafeProtocolRegistry<br>and validate if Plugin trusted}
+    ExamplePlugin1 -->|Execute tx for an Account through Plugin| Execute_Transaction(Execute transaction from a Plugin) --> Validate_ExecuteFromPluginFlow{Is Plugin Enabled?<br>Call SafeProtocolRegistry<br>and validate if Plugin trusted}
     Validate_ExecuteFromPluginFlow -- No ----> E(Revert transaction) 
 end
 ```
 
-## Safe transaction execution with Hooks
+## Account transaction execution with Hooks
 
 ```mermaid
 ---
@@ -58,14 +58,14 @@ subgraph Users
    User(User)
 end
 
-subgraph SafeAccounts
-   User(User) -->|Execute Safe Tx| SafeAccount
+subgraph Accounts
+   User(User) -->|Execute Tx| Account
    End
 end
 
-subgraph SafeAccount [Safe with SafeProtocolManager enabled as Hook]
+subgraph SafeAccount [Account with SafeProtocolManager enabled as Hook]
    PreCheck_Hook
-   PreCheck_Hook("Pre-check Hook") -->|On passing pre-checks| ExecuteTx(Execute Safe Transaction)
+   PreCheck_Hook("Pre-check Hook") -->|On passing pre-checks| ExecuteTx(Execute Account Transaction)
    ExecuteTx -->|On successful execution| PostCheckHook(Post-check hook)
    PostCheckHook -->|On passing post checks| End
 end
@@ -111,11 +111,11 @@ subgraph SignatureValidator [Signature validator enabled for the given Safe]
 end
 
 Sign_Transaction --> RequestToValidate
-RequestToValidate(Call to validate a Signature for given Safe) --> SafeProtocolManager
+RequestToValidate(Call to validate a Signature for a given Account) --> SafeProtocolManager
 
 SafeProtocolManager --> isValidSignature{isValidSignature}
 
 isValidSignature --> |Yes| ExecuteTx(Continue transaction execution)
 
-User("`Users(s)`") --> |Generate a Safe signature| Sign_Transaction
+User("`Users(s)`") --> |Generate an Account signature| Sign_Transaction
 ```

--- a/test/SafeProtocolManager.spec.ts
+++ b/test/SafeProtocolManager.spec.ts
@@ -623,7 +623,7 @@ describe("SafeProtocolManager", async () => {
 
             it("Should process a SafeTransaction with hooks enabled and transfer ETH from an account to an EOA", async () => {
                 const { safeProtocolManager, account, safeProtocolRegistry } = await loadFixture(deployContractsWithEnabledManagerFixture);
-                // Enable hooks on a safe
+                // Enable hooks on the account
                 const hooks = await getHooksWithPassingChecks();
                 await safeProtocolRegistry.connect(owner).addModule(hooks.target, ModuleType.Hooks);
                 const dataSetHooks = safeProtocolManager.interface.encodeFunctionData("setHooks", [await hooks.getAddress()]);
@@ -674,7 +674,7 @@ describe("SafeProtocolManager", async () => {
 
             it("Should fail executing a transaction through plugin when hooks pre-check fails", async () => {
                 const { safeProtocolManager, account, safeProtocolRegistry } = await loadFixture(deployContractsWithEnabledManagerFixture);
-                // Enable hooks on a safe
+                // Enable hooks on the account
                 const hooks = await getHooksWithFailingPrechecks();
                 await safeProtocolRegistry.connect(owner).addModule(hooks.target, ModuleType.Hooks);
 
@@ -698,7 +698,7 @@ describe("SafeProtocolManager", async () => {
 
             it("Should fail executing a transaction through plugin when hooks post-check fails", async () => {
                 const { safeProtocolManager, account, safeProtocolRegistry } = await loadFixture(deployContractsWithEnabledManagerFixture);
-                // Enable hooks on a safe
+                // Enable hooks on the account
                 const hooks = await getHooksWithFailingPostCheck();
                 await safeProtocolRegistry.connect(owner).addModule(hooks.target, ModuleType.Hooks);
 
@@ -857,7 +857,7 @@ describe("SafeProtocolManager", async () => {
             it("Should execute a transaction from root access enabled plugin with hooks enabled", async () => {
                 const { safeProtocolManager, account, safeProtocolRegistry } = await loadFixture(deployContractsWithEnabledManagerFixture);
 
-                // Enable hooks on a safe
+                // Enable hooks on the account
                 const hooks = await getHooksWithPassingChecks();
                 await safeProtocolRegistry.connect(owner).addModule(hooks.target, ModuleType.Hooks);
 
@@ -918,7 +918,7 @@ describe("SafeProtocolManager", async () => {
 
             it("Should fail to execute a transaction from root access enabled plugin when hooks pre-check fails", async () => {
                 const { safeProtocolManager, account, safeProtocolRegistry } = await loadFixture(deployContractsWithEnabledManagerFixture);
-                // Enable hooks on a safe
+                // Enable hooks on the account
                 const hooks = await getHooksWithFailingPrechecks();
                 await safeProtocolRegistry.connect(owner).addModule(hooks.target, ModuleType.Hooks);
 
@@ -953,7 +953,7 @@ describe("SafeProtocolManager", async () => {
             it("Should fail to execute a transaction from root access enabled plugin when hooks post-check fails", async () => {
                 const { safeProtocolManager, account, safeProtocolRegistry } = await loadFixture(deployContractsWithEnabledManagerFixture);
 
-                // Enable hooks on a safe
+                // Enable hooks on the account
                 const hooks = await getHooksWithFailingPostCheck();
                 await safeProtocolRegistry.connect(owner).addModule(hooks.target, ModuleType.Hooks);
 
@@ -1153,7 +1153,7 @@ describe("SafeProtocolManager", async () => {
                 await hre.ethers.getContractFactory("SafeProtocolManager")
             ).deploy(owner.address, safeProtocolRegistry.target);
 
-            const safe = await hre.ethers.deployContract("TestExecutor", [safeProtocolManager.target], { signer: deployer });
+            const account = await hre.ethers.deployContract("TestExecutor", [safeProtocolManager.target], { signer: deployer });
 
             const hooks = await getHooksWithPassingChecks();
             const hooksWithFailingPreChecks = await getHooksWithFailingPrechecks();
@@ -1163,11 +1163,11 @@ describe("SafeProtocolManager", async () => {
             await safeProtocolRegistry.connect(owner).addModule(hooksWithFailingPreChecks.target, ModuleType.Hooks);
             await safeProtocolRegistry.connect(owner).addModule(hooksWithFailingPostCheck.target, ModuleType.Hooks);
 
-            return { safe, safeProtocolManager, hooks, hooksWithFailingPreChecks, hooksWithFailingPostCheck };
+            return { account, safeProtocolManager, hooks, hooksWithFailingPreChecks, hooksWithFailingPostCheck };
         });
 
         it("Should not revert when no hooks registered on SafeProtocolManager", async () => {
-            const { safe, safeProtocolManager } = await setupTests();
+            const { account, safeProtocolManager } = await setupTests();
 
             const execPreChecks = safeProtocolManager.interface.encodeFunctionData("checkTransaction", [
                 user2.address,
@@ -1182,18 +1182,18 @@ describe("SafeProtocolManager", async () => {
                 "0x",
                 ZeroAddress,
             ]);
-            expect(await safe.executeCallViaMock(safeProtocolManager.target, 0, execPreChecks, MaxUint256));
+            expect(await account.executeCallViaMock(safeProtocolManager.target, 0, execPreChecks, MaxUint256));
 
             const execPostChecks = safeProtocolManager.interface.encodeFunctionData("checkAfterExecution", [
                 hre.ethers.randomBytes(32),
                 true,
             ]);
 
-            expect(await safe.executeCallViaMock(safeProtocolManager.target, 0, execPostChecks, MaxUint256));
+            expect(await account.executeCallViaMock(safeProtocolManager.target, 0, execPostChecks, MaxUint256));
         });
 
         it("Should not revert when no hooks registered on SafeProtocolManager for module transaction", async () => {
-            const { safe, safeProtocolManager } = await setupTests();
+            const { account, safeProtocolManager } = await setupTests();
 
             const execPreChecks = safeProtocolManager.interface.encodeFunctionData("checkModuleTransaction", [
                 user2.address,
@@ -1202,21 +1202,21 @@ describe("SafeProtocolManager", async () => {
                 0, // Call operation
                 ZeroAddress,
             ]);
-            expect(await safe.executeCallViaMock(safeProtocolManager.target, 0, execPreChecks, MaxUint256));
+            expect(await account.executeCallViaMock(safeProtocolManager.target, 0, execPreChecks, MaxUint256));
 
             const execPostChecks = safeProtocolManager.interface.encodeFunctionData("checkAfterExecution", [
                 hre.ethers.randomBytes(32),
                 true,
             ]);
 
-            expect(await safe.executeCallViaMock(safeProtocolManager.target, 0, execPostChecks, MaxUint256));
+            expect(await account.executeCallViaMock(safeProtocolManager.target, 0, execPostChecks, MaxUint256));
         });
 
         it("Should revert because hooks reverted in pre-check", async () => {
-            const { safe, safeProtocolManager, hooksWithFailingPreChecks } = await setupTests();
-            // Set Hooks contract for the Safe
+            const { account, safeProtocolManager, hooksWithFailingPreChecks } = await setupTests();
+            // Set Hooks contract for the account
             const dataSetHooks = safeProtocolManager.interface.encodeFunctionData("setHooks", [hooksWithFailingPreChecks.target]);
-            await safe.executeCallViaMock(safe.target, 0, dataSetHooks, MaxUint256);
+            await account.executeCallViaMock(account.target, 0, dataSetHooks, MaxUint256);
 
             const execChecks = safeProtocolManager.interface.encodeFunctionData("checkTransaction", [
                 user2.address,
@@ -1232,16 +1232,16 @@ describe("SafeProtocolManager", async () => {
                 ZeroAddress,
             ]);
 
-            await expect(safe.executeCallViaMock(safeProtocolManager.target, 0, execChecks, MaxUint256)).to.be.revertedWith(
+            await expect(account.executeCallViaMock(safeProtocolManager.target, 0, execChecks, MaxUint256)).to.be.revertedWith(
                 "pre-check failed",
             );
         });
 
         it("Should revert because hooks reverted in post-check", async () => {
-            const { safe, safeProtocolManager, hooksWithFailingPostCheck } = await setupTests();
-            // Set Hooks contract for the Safe
+            const { account, safeProtocolManager, hooksWithFailingPostCheck } = await setupTests();
+            // Set Hooks contract for the account
             const dataSetHooks = safeProtocolManager.interface.encodeFunctionData("setHooks", [hooksWithFailingPostCheck.target]);
-            await safe.executeCallViaMock(safe.target, 0, dataSetHooks, MaxUint256);
+            await account.executeCallViaMock(account.target, 0, dataSetHooks, MaxUint256);
 
             // Required to execute pre-checks to set tempHooksAddress[msg.sender]
             const execPreChecks = safeProtocolManager.interface.encodeFunctionData("checkTransaction", [
@@ -1257,23 +1257,23 @@ describe("SafeProtocolManager", async () => {
                 "0x",
                 ZeroAddress,
             ]);
-            await safe.executeCallViaMock(safeProtocolManager.target, 0, execPreChecks, MaxUint256);
+            await account.executeCallViaMock(safeProtocolManager.target, 0, execPreChecks, MaxUint256);
 
             const execPostChecks = safeProtocolManager.interface.encodeFunctionData("checkAfterExecution", [
                 hre.ethers.randomBytes(32),
                 true,
             ]);
 
-            await expect(safe.executeCallViaMock(safeProtocolManager.target, 0, execPostChecks, MaxUint256)).to.be.revertedWith(
+            await expect(account.executeCallViaMock(safeProtocolManager.target, 0, execPostChecks, MaxUint256)).to.be.revertedWith(
                 "post-check failed",
             );
         });
 
         it("Should pass hooks checks", async () => {
-            const { safe, safeProtocolManager, hooks } = await setupTests();
-            // Set Hooks contract for the Safe
+            const { account, safeProtocolManager, hooks } = await setupTests();
+            // Set Hooks contract for the account
             const dataSetHooks = safeProtocolManager.interface.encodeFunctionData("setHooks", [hooks.target]);
-            await safe.executeCallViaMock(safe.target, 0, dataSetHooks, MaxUint256);
+            await account.executeCallViaMock(account.target, 0, dataSetHooks, MaxUint256);
 
             const execPreChecks = safeProtocolManager.interface.encodeFunctionData("checkTransaction", [
                 user2.address,
@@ -1288,30 +1288,30 @@ describe("SafeProtocolManager", async () => {
                 "0x",
                 ZeroAddress,
             ]);
-            expect(await safe.executeCallViaMock(safeProtocolManager.target, 0, execPreChecks, MaxUint256));
+            expect(await account.executeCallViaMock(safeProtocolManager.target, 0, execPreChecks, MaxUint256));
 
             const execPostChecks = safeProtocolManager.interface.encodeFunctionData("checkAfterExecution", [
                 hre.ethers.randomBytes(32),
                 true,
             ]);
 
-            expect(await safe.executeCallViaMock(safeProtocolManager.target, 0, execPostChecks, MaxUint256));
+            expect(await account.executeCallViaMock(safeProtocolManager.target, 0, execPostChecks, MaxUint256));
 
             // Check if temporary hooks related storage is cleared after tx
-            expect(await safeProtocolManager.tempHooksData.staticCall(safe.target)).to.deep.equal([ZeroAddress, "0x"]);
+            expect(await safeProtocolManager.tempHooksData.staticCall(account.target)).to.deep.equal([ZeroAddress, "0x"]);
 
             const mockHooks = await getInstance<MockContract>("MockContract", hooks.target);
             // Pre-check hooks calls
             expect(await mockHooks.invocationCountForMethod("0x176ae7b7")).to.equal(1);
-            const postCheckCallData = hooks.interface.encodeFunctionData("postCheck", [safe.target, true, "0xdeadbeef"]);
+            const postCheckCallData = hooks.interface.encodeFunctionData("postCheck", [account.target, true, "0xdeadbeef"]);
             expect(await mockHooks.invocationCountForCalldata(postCheckCallData)).to.equal(1);
         });
 
         it("Should pass hooks checks for module transaction with call operation", async () => {
-            const { safe, safeProtocolManager, hooks } = await setupTests();
-            // Set Hooks contract for the Safe
+            const { account, safeProtocolManager, hooks } = await setupTests();
+            // Set Hooks contract for the account
             const dataSetHooks = safeProtocolManager.interface.encodeFunctionData("setHooks", [hooks.target]);
-            await safe.executeCallViaMock(safe.target, 0, dataSetHooks, MaxUint256);
+            await account.executeCallViaMock(account.target, 0, dataSetHooks, MaxUint256);
 
             const execPreChecks = safeProtocolManager.interface.encodeFunctionData("checkModuleTransaction", [
                 user2.address,
@@ -1321,38 +1321,38 @@ describe("SafeProtocolManager", async () => {
                 ZeroAddress,
             ]);
 
-            expect(await safe.executeCallViaMock(safeProtocolManager.target, 0, execPreChecks, MaxUint256));
+            expect(await account.executeCallViaMock(safeProtocolManager.target, 0, execPreChecks, MaxUint256));
 
             const execPostChecks = safeProtocolManager.interface.encodeFunctionData("checkAfterExecution", [
                 hre.ethers.randomBytes(32),
                 true,
             ]);
-            expect(await safe.executeCallViaMock(safeProtocolManager.target, 0, execPostChecks, MaxUint256));
+            expect(await account.executeCallViaMock(safeProtocolManager.target, 0, execPostChecks, MaxUint256));
 
             // Check if temporary hooks related storage is cleared after tx
-            expect(await safeProtocolManager.tempHooksData.staticCall(safe.target)).to.deep.equal([ZeroAddress, "0x"]);
+            expect(await safeProtocolManager.tempHooksData.staticCall(account.target)).to.deep.equal([ZeroAddress, "0x"]);
 
             const mockHooks = await getInstance<MockContract>("MockContract", hooks.target);
             // preCheck hooks calls
             const safeTx = buildSingleTx(user2.address, 0n, "0x", 0n, hre.ethers.ZeroHash);
             const preCheckCalldata = hooks.interface.encodeFunctionData("preCheck", [
-                safe.target,
+                account.target,
                 safeTx,
                 1,
                 hre.ethers.AbiCoder.defaultAbiCoder().encode(["address"], [ZeroAddress]),
             ]);
             expect(await mockHooks.invocationCountForMethod("0x176ae7b7")).to.equal(1);
             expect(await mockHooks.invocationCountForCalldata(preCheckCalldata)).to.equal(1);
-            const postCheckCallData = hooks.interface.encodeFunctionData("postCheck", [safe.target, true, "0x"]);
+            const postCheckCallData = hooks.interface.encodeFunctionData("postCheck", [account.target, true, "0x"]);
 
             expect(await mockHooks.invocationCountForCalldata(postCheckCallData)).to.equal(1);
         });
 
         it("Should pass hooks checks for module transaction with delegateCall operation", async () => {
-            const { safe, safeProtocolManager, hooks } = await setupTests();
-            // Set Hooks contract for the Safe
+            const { account, safeProtocolManager, hooks } = await setupTests();
+            // Set Hooks contract for the account
             const dataSetHooks = safeProtocolManager.interface.encodeFunctionData("setHooks", [hooks.target]);
-            await safe.executeCallViaMock(safe.target, 0, dataSetHooks, MaxUint256);
+            await account.executeCallViaMock(account.target, 0, dataSetHooks, MaxUint256);
 
             const execPreChecks = safeProtocolManager.interface.encodeFunctionData("checkModuleTransaction", [
                 user2.address,
@@ -1362,20 +1362,20 @@ describe("SafeProtocolManager", async () => {
                 ZeroAddress,
             ]);
 
-            expect(await safe.executeCallViaMock(safeProtocolManager.target, 0, execPreChecks, MaxUint256));
+            expect(await account.executeCallViaMock(safeProtocolManager.target, 0, execPreChecks, MaxUint256));
 
             const execPostChecks = safeProtocolManager.interface.encodeFunctionData("checkAfterExecution", [
                 hre.ethers.randomBytes(32),
                 true,
             ]);
 
-            expect(await safe.executeCallViaMock(safeProtocolManager.target, 0, execPostChecks, MaxUint256));
+            expect(await account.executeCallViaMock(safeProtocolManager.target, 0, execPostChecks, MaxUint256));
 
             const mockHooks = await getInstance<MockContract>("MockContract", hooks.target);
             // preCheck hooks calls
             const safeTx = buildRootTx(user2.address, 0n, "0x", 0n, hre.ethers.ZeroHash);
             const preCheckCalldata = hooks.interface.encodeFunctionData("preCheckRootAccess", [
-                safe.target,
+                account.target,
                 safeTx,
                 1,
                 hre.ethers.AbiCoder.defaultAbiCoder().encode(["address"], [ZeroAddress]),
@@ -1383,16 +1383,16 @@ describe("SafeProtocolManager", async () => {
             // 0x7359b742 -> preCheckRootAccess function signature
             expect(await mockHooks.invocationCountForMethod("0x7359b742")).to.equal(1);
             expect(await mockHooks.invocationCountForCalldata(preCheckCalldata)).to.equal(1);
-            const postCheckCallData = hooks.interface.encodeFunctionData("postCheck", [safe.target, true, "0x"]);
+            const postCheckCallData = hooks.interface.encodeFunctionData("postCheck", [account.target, true, "0x"]);
 
             expect(await mockHooks.invocationCountForCalldata(postCheckCallData)).to.equal(1);
         });
 
         it("Should pass hooks checks for delegateCall operation", async () => {
-            const { safe, safeProtocolManager, hooks } = await setupTests();
-            // Set Hooks contract for the Safe
+            const { account, safeProtocolManager, hooks } = await setupTests();
+            // Set Hooks contract for the account
             const dataSetHooks = safeProtocolManager.interface.encodeFunctionData("setHooks", [hooks.target]);
-            await safe.executeCallViaMock(safe.target, 0, dataSetHooks, MaxUint256);
+            await account.executeCallViaMock(account.target, 0, dataSetHooks, MaxUint256);
 
             const execPreChecks = safeProtocolManager.interface.encodeFunctionData("checkTransaction", [
                 user2.address,
@@ -1407,29 +1407,29 @@ describe("SafeProtocolManager", async () => {
                 "0x",
                 ZeroAddress,
             ]);
-            expect(await safe.executeCallViaMock(safeProtocolManager.target, 0, execPreChecks, MaxUint256));
+            expect(await account.executeCallViaMock(safeProtocolManager.target, 0, execPreChecks, MaxUint256));
 
             const execPostChecks = safeProtocolManager.interface.encodeFunctionData("checkAfterExecution", [
                 hre.ethers.randomBytes(32),
                 true,
             ]);
 
-            expect(await safe.executeCallViaMock(safeProtocolManager.target, 0, execPostChecks, MaxUint256));
+            expect(await account.executeCallViaMock(safeProtocolManager.target, 0, execPostChecks, MaxUint256));
 
             const mockHooks = await getInstance<MockContract>("MockContract", hooks.target);
             // preCheckRootAccess hooks calls
             expect(await mockHooks.invocationCountForMethod("0x7359b742")).to.equal(1);
-            const postCheckCallData = hooks.interface.encodeFunctionData("postCheck", [safe.target, true, "0xbaddad"]);
+            const postCheckCallData = hooks.interface.encodeFunctionData("postCheck", [account.target, true, "0xbaddad"]);
             expect(await mockHooks.invocationCountForCalldata(postCheckCallData)).to.equal(1);
         });
 
         it("uses old hooks in checkAfterExecution if hooks get updated in between transactions", async () => {
             // In below flow: pre-check of hooksWithFailingPostCheck is executed, and post-check of
             // hooksWithFailingPostCheck hooks is executed even though hooks get updated in between tx.
-            const { safe, safeProtocolManager, hooksWithFailingPostCheck, hooks } = await setupTests();
-            // Set Hooks contract for the Safe
+            const { account, safeProtocolManager, hooksWithFailingPostCheck, hooks } = await setupTests();
+            // Set Hooks contract for the account
             const dataSetHooks = safeProtocolManager.interface.encodeFunctionData("setHooks", [hooksWithFailingPostCheck.target]);
-            await safe.executeCallViaMock(safe.target, 0, dataSetHooks, MaxUint256);
+            await account.executeCallViaMock(account.target, 0, dataSetHooks, MaxUint256);
 
             // Required to execute pre-checks to set tempHooksAddress[msg.sender]
             const execPreChecks = safeProtocolManager.interface.encodeFunctionData("checkTransaction", [
@@ -1445,17 +1445,17 @@ describe("SafeProtocolManager", async () => {
                 "0x",
                 ZeroAddress,
             ]);
-            await safe.executeCallViaMock(safeProtocolManager.target, 0, execPreChecks, MaxUint256);
+            await account.executeCallViaMock(safeProtocolManager.target, 0, execPreChecks, MaxUint256);
 
             const txData = safeProtocolManager.interface.encodeFunctionData("setHooks", [hooks.target]);
-            await safe.executeCallViaMock(safe.target, 0, txData, MaxUint256);
+            await account.executeCallViaMock(account.target, 0, txData, MaxUint256);
 
             const execPostChecks = safeProtocolManager.interface.encodeFunctionData("checkAfterExecution", [
                 hre.ethers.randomBytes(32),
                 true,
             ]);
 
-            await expect(safe.executeCallViaMock(safeProtocolManager.target, 0, execPostChecks, MaxUint256)).to.be.revertedWith(
+            await expect(account.executeCallViaMock(safeProtocolManager.target, 0, execPostChecks, MaxUint256)).to.be.revertedWith(
                 "post-check failed",
             );
         });


### PR DESCRIPTION
This PR is an addition to https://github.com/safe-global/safe-core-protocol-specs/pull/38

As discussed earlier, we believe the protocol should be account-agnostic (as long as the account implements the required API by the spec). We often called the account used in the protocol a safe. This PR fixes this and replaces it with a generic `account` name.