### PR TITLE
Add Maintenance Disclaimer to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**:warning: This repository is not actively developed at the moment. :warning:**
+
 [![Coverage Status](https://coveralls.io/repos/github/safe-global/safe-core-protocol/badge.svg)](https://coveralls.io/github/safe-global/safe-core-protocol)
 
 # Safe{Core} Protocol


### PR DESCRIPTION
This PR adds a disclaimer to the README that the repository is no longer being actively developed at the moment by the protocol team, although we expect to resume development some time in the near future.